### PR TITLE
KaamelottBot, le bot Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,6 @@ Whoooohoooo woa c'est mortel !
 * [Application Android](https://gitlab.com/astran/kaamelottsb) pas encore sur le store mais il y a un [lien pour l'apk de dev](https://gitlab.com/astran/kaamelottsb/-/jobs/artifacts/master/raw/app/build/outputs/apk/debug/app-debug.apk?job=assembleDebug) 
 * [Bot Telegram](https://github.com/klmp200/kaamelott-soundboard-telegram-bot)
 * [VoiceBot](https://github.com/scastrec/kaamelottvoice) Pour l'instant, uniquement Alexa, mais déclinable rapidement en Google Assistant si demandes
+* [KaamelottBot](https://github.com/pumbaa666/KaamelottBot) est un bot [Discord](https://discord.com) rigolo qui joue des sons ou affiche des gifs animés dans votre channel Discord `# Bon ben révolte ! TUUUUUUUUT !!`
 
 Merci, de rien, au revoir m'sieur dame


### PR DESCRIPTION
Un bot Discord à la con mais assez complet.
Vous pouvez jouer n'importe quel son de la base de donnée (près de 700 à ce jour) dans votre chan audio pour embêter ou faire marrer vos collègues.
Jouez-en un au hasard en invoquant la commande `/kaamelott-audio` ou chercher un mot-clé/titre/personnage en particulier `/kaamelott-audio [Perso] Leodagan`
`/kaamelott-audio [Titre] La Table de Breccan`

Vous pouvez aussi afficher un des 1'000 (!) gifs animés venant de ce projet : [kaamelott-gifboard](https://github.com/kaamelott-gifboard/kaamelott-gifboard)
`/kaamelott-gifs [Perso] Arthur`

Toute la doc pour installer le bot (voire le faire tourner vous-même) est dispo sur [mon repo github](https://github.com/pumbaa666/KaamelottBot).